### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: maven
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify


### PR DESCRIPTION
Problem: Maven cache setup in setup-java@v2 caused random 422 HTTP errors due to corrupted internal cache handling in GitHub Actions.
Solution: Updated setup-java to version v3 and switched to distribution: 'temurin'.
Result: Maven cache is now working automatically and builds are passing successfully.